### PR TITLE
fix: Fix Helm chart template logic

### DIFF
--- a/charts/newrelic-agent-operator/templates/_helpers.tpl
+++ b/charts/newrelic-agent-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "newrelic-agent-operator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -11,16 +11,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "newrelic-agent-operator.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -80,3 +71,10 @@ Returns if the template should render, it checks if the required values are set.
 {{- $licenseKey := include "newrelic-agent-operator.licenseKey" . -}}
 {{- and (or $licenseKey)}}
 {{- end -}}
+
+{{/*
+Controller manager service certificate's secret.
+*/}}
+{{- define "newrelic-agent-operator.certificateSecret" -}}
+{{- printf "%s-controller-manager-service-cert" (include "newrelic-agent-operator.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/newrelic-agent-operator/templates/certmanager.yaml
+++ b/charts/newrelic-agent-operator/templates/certmanager.yaml
@@ -12,7 +12,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: '{{ template "newrelic-agent-operator.fullname" . }}-selfsigned-issuer'
-  secretName: newrelic-agent-operator-controller-manager-service-cert
+  secretName: {{ template "newrelic-agent-operator.certificateSecret" . }}
   subject:
     organizationalUnits:
     - newrelic-agent-operator

--- a/charts/newrelic-agent-operator/templates/deployment.yaml
+++ b/charts/newrelic-agent-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "newrelic-agent-operator.fullname" . }}
+  name: {{ template "newrelic-agent-operator.serviceAccountName" . }}
   labels:
   {{- include "newrelic-agent-operator.labels" . | nindent 4 }}
 ---
@@ -89,7 +89,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: {{ default (printf "%s-controller-manager-service-cert" (include "newrelic-agent-operator.fullname" .)) .Values.admissionWebhooks.secretName }} 
+          secretName: {{ template "newrelic-agent-operator.certificateSecret" . }}
       {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}

--- a/charts/newrelic-agent-operator/templates/leader-election-rbac.yaml
+++ b/charts/newrelic-agent-operator/templates/leader-election-rbac.yaml
@@ -45,5 +45,5 @@ roleRef:
   name: '{{ template "newrelic-agent-operator.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ template "newrelic-agent-operator.fullname" . }}'
+  name: '{{ template "newrelic-agent-operator.serviceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/newrelic-agent-operator/templates/manager-rbac.yaml
+++ b/charts/newrelic-agent-operator/templates/manager-rbac.yaml
@@ -72,5 +72,5 @@ roleRef:
   name: '{{ template "newrelic-agent-operator.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ template "newrelic-agent-operator.fullname" . }}'
+  name: '{{ template "newrelic-agent-operator.serviceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/newrelic-agent-operator/templates/proxy-rbac.yaml
+++ b/charts/newrelic-agent-operator/templates/proxy-rbac.yaml
@@ -30,5 +30,5 @@ roleRef:
   name: '{{ template "newrelic-agent-operator.fullname" . }}-proxy-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ template "newrelic-agent-operator.fullname" . }}'
+  name: '{{ template "newrelic-agent-operator.serviceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/newrelic-agent-operator/values.yaml
+++ b/charts/newrelic-agent-operator/values.yaml
@@ -27,7 +27,6 @@ controllerManager:
     # -- Create the manager ServiceAccount
     serviceAccount:
       create: true
-      # name: nameOverride
 
     ## Enable leader election mechanism for protecting against split brain if multiple operator pods/replicas are started.
     ## See more at https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-leader-election.html
@@ -60,4 +59,3 @@ securityContext:
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 admissionWebhooks:
   create: true
-  secretName: ""


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
While working in the creation of the Docker registry, I found an issue blocking the operator from being installed.

After triaging, I found the issue is that the Helm chart only works for the release name specified in the docs. This is a critical flaw, since the customer controls the release name, not us.

Specifically, changing the release name broke the logic for the creation and usage of the service account, which impacted all aspects of the chart: deployment of pods, cluster roles, RBAC rules. Additionally, the certificate hard-coded the secret name, while other entities used the templatized name.

The challenge for debugging the issue is that the Helm chart is a hack that used a template with unused variables that were not removed, masking the root cause and leading to multiple red herrings.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  