### PR TITLE
chore: Update CODEOWNERS for .NET

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 * @newrelic/k8s-agents
 
 # APM team owned directories
-/src/apm/ @newrelic/dotnet @newrelic/go-agent @newrelic/java-agent @newrelic/node-js-agent @newrelic/php-agent @newrelic/python @newrelic/ruby-agent
+/src/apm/ @newrelic/dotnet-code-reviewers @newrelic/go-agent @newrelic/java-agent @newrelic/node-js-agent @newrelic/php-agent @newrelic/python @newrelic/ruby-agent


### PR DESCRIPTION
Updates the team name in `CODEOWNERS` to reference the correct .NET team.