### PR TITLE
fix: Removed Duplicate "app.kubernetes.io/name" keys in Helm Chart.

### DIFF
--- a/charts/k8s-agents-operator/templates/deployment.yaml
+++ b/charts/k8s-agents-operator/templates/deployment.yaml
@@ -16,13 +16,11 @@ spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: k8s-agents-operator
       control-plane: controller-manager
     {{- include "k8s-agents-operator.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: k8s-agents-operator
         control-plane: controller-manager
       {{- include "k8s-agents-operator.labels" . | nindent 8 }}
     spec:

--- a/charts/k8s-agents-operator/templates/service.yaml
+++ b/charts/k8s-agents-operator/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   type: {{ .Values.metricsService.type }}
   selector:
-    app.kubernetes.io/name: {{ include "k8s-agents-operator.chart" . }}
     control-plane: controller-manager
   {{- include "k8s-agents-operator.labels" . | nindent 4 }}
   ports:

--- a/charts/k8s-agents-operator/templates/webhook-service.yaml
+++ b/charts/k8s-agents-operator/templates/webhook-service.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   type: {{ .Values.webhookService.type }}
   selector:
-    app.kubernetes.io/name: {{ include "k8s-agents-operator.chart" . }}
-    app.kubernetes.io/name: k8s-agents-operator
     control-plane: controller-manager
   {{- include "k8s-agents-operator.labels" . | nindent 4 }}
   ports:


### PR DESCRIPTION
## Description
The Helm Chart showed errors due to duplicate app.kubernetes.io/name keys in the Deployment and some Services.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  