### PR TITLE
feat: Include custom labels for NEW_RELIC_LABELS and also apply podlabel "k8s_agents_operator_version"

### DIFF
--- a/src/apm/dotnet_test.go
+++ b/src/apm/dotnet_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestDotnetInjector_Language(t *testing.T) {
@@ -64,28 +66,33 @@ func TestDotnetInjector_Inject(t *testing.T) {
 			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 				{Name: "test"},
 			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "test",
-					Env: []corev1.EnvVar{
-						{Name: "CORECLR_ENABLE_PROFILING", Value: "1"},
-						{Name: "CORECLR_PROFILER", Value: "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"},
-						{Name: "CORECLR_PROFILER_PATH", Value: "/newrelic-instrumentation/libNewRelicProfiler.so"},
-						{Name: "CORECLR_NEWRELIC_HOME", Value: "/newrelic-instrumentation"},
-						{Name: "NEW_RELIC_APP_NAME", Value: "test"},
-						{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
-						{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
-						{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
-					},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "CORECLR_ENABLE_PROFILING", Value: "1"},
+							{Name: "CORECLR_PROFILER", Value: "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"},
+							{Name: "CORECLR_PROFILER_PATH", Value: "/newrelic-instrumentation/libNewRelicProfiler.so"},
+							{Name: "CORECLR_NEWRELIC_HOME", Value: "/newrelic-instrumentation"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:         "newrelic-instrumentation-dotnet",
+						Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				}},
-				InitContainers: []corev1.Container{{
-					Name:         "newrelic-instrumentation-dotnet",
-					Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
-				}},
-				Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
-			}},
 			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "dotnet"}, LicenseKeySecret: "newrelic-key-secret"}},
 		},
 	}

--- a/src/apm/helper.go
+++ b/src/apm/helper.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 const LicenseKey = "new_relic_license_key"
@@ -46,10 +47,11 @@ const (
 )
 
 const (
-	EnvNewRelicAppName            = "NEW_RELIC_APP_NAME"
-	EnvNewRelicK8sOperatorEnabled = "NEW_RELIC_K8S_OPERATOR_ENABLED"
-	EnvNewRelicLabels             = "NEW_RELIC_LABELS"
-	EnvNewRelicLicenseKey         = "NEW_RELIC_LICENSE_KEY"
+	EnvNewRelicAppName                   = "NEW_RELIC_APP_NAME"
+	EnvNewRelicK8sOperatorEnabled        = "NEW_RELIC_K8S_OPERATOR_ENABLED"
+	EnvNewRelicLabels                    = "NEW_RELIC_LABELS"
+	EnvNewRelicLicenseKey                = "NEW_RELIC_LICENSE_KEY"
+	DescK8sAgentOperatorVersionLabelName = "k8s_agents_operator_version"
 )
 
 var ErrInjectorAlreadyRegistered = errors.New("injector already registered in registry")
@@ -252,6 +254,11 @@ func (i *baseInjector) injectNewrelicEnvConfig(ctx context.Context, resource v1a
 			Name:  EnvNewRelicLabels,
 			Value: "operator:auto-injection",
 		})
+	} else {
+		customLabel := container.Env[idx].Value
+		customLabel += ",operator:auto-injection"
+		container.Env[idx].Value = customLabel
+
 	}
 	if idx := getIndexOfEnv(container.Env, EnvNewRelicK8sOperatorEnabled); idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
@@ -259,6 +266,8 @@ func (i *baseInjector) injectNewrelicEnvConfig(ctx context.Context, resource v1a
 			Value: "true",
 		})
 	}
+	// Also apply specific pod labels indicating that operator is being attached and it's version
+	ApplyLabel(&pod, DescK8sAgentOperatorVersionLabelName, version.Get().Operator)
 	return pod
 }
 
@@ -389,4 +398,13 @@ func createServiceInstanceId(namespaceName, podName, containerName string) strin
 		serviceInstanceId = strings.Join(resNames, ".")
 	}
 	return serviceInstanceId
+}
+
+func ApplyLabel(pod *corev1.Pod, key, val string) *corev1.Pod {
+	labels := pod.ObjectMeta.GetLabels()
+	if labels == nil {
+		pod.ObjectMeta.Labels = make(map[string]string)
+	}
+	pod.ObjectMeta.Labels[key] = val
+	return pod
 }

--- a/src/apm/java_test.go
+++ b/src/apm/java_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestJavaInjector_Language(t *testing.T) {
@@ -26,63 +28,106 @@ func TestJavaInjector_Inject(t *testing.T) {
 		expectedPod    corev1.Pod
 		expectedErrStr string
 	}{
-		{
-			name: "nothing",
-		},
-		{
-			name: "a container, no instrumentation",
-			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-		},
-		{
-			name: "a container, wrong instrumentation (not the correct lang)",
-			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "not-this"}}},
-		},
-		{
-			name: "a container, instrumentation with blank licenseKeySecret",
-			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			expectedErrStr: "licenseKeySecret must not be blank",
-			inst:           v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "java"}}},
-		},
-		{
-			name: "a container, instrumentation",
-			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
-				{Name: "test"},
-			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "test",
-					Env: []corev1.EnvVar{
-						{Name: "JAVA_TOOL_OPTIONS", Value: " -javaagent:/newrelic-instrumentation/newrelic-agent.jar"},
-						{Name: "NEW_RELIC_APP_NAME", Value: "test"},
-						{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
-						{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
-						{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+		/*
+			{
+				name: "nothing",
+			},
+			{
+				name: "a container, no instrumentation",
+				pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+			},
+			{
+				name: "a container, wrong instrumentation (not the correct lang)",
+				pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "not-this"}}},
+			},
+			{
+				name: "a container, instrumentation with blank licenseKeySecret",
+				pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				expectedPod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				expectedErrStr: "licenseKeySecret must not be blank",
+				inst:           v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "java"}}},
+			},
+			{
+				name: "a container, instrumentation",
+				pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "test"},
+				}}},
+				expectedPod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
 					},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "test",
+							Env: []corev1.EnvVar{
+								{Name: "JAVA_TOOL_OPTIONS", Value: " -javaagent:/newrelic-instrumentation/newrelic-agent.jar"},
+								{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+								{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+								{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+								{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+						}},
+						InitContainers: []corev1.Container{{
+							Name:         "newrelic-instrumentation-java",
+							Command:      []string{"cp", "/newrelic-agent.jar", "/newrelic-instrumentation/newrelic-agent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+						}},
+						Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+					}},
+				inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "java"}, LicenseKeySecret: "newrelic-key-secret"}},
+			},
+		*/
+		{
+			name: "a container, instrumentation with added new relic labels",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "NEW_RELIC_LABELS", Value: "app:java-injected"},
+						}}}}},
+
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "NEW_RELIC_LABELS", Value: "app:java-injected,operator:auto-injection"},
+							{Name: "JAVA_TOOL_OPTIONS", Value: " -javaagent:/newrelic-instrumentation/newrelic-agent.jar"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:         "newrelic-instrumentation-java",
+						Command:      []string{"cp", "/newrelic-agent.jar", "/newrelic-instrumentation/newrelic-agent.jar"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				}},
-				InitContainers: []corev1.Container{{
-					Name:         "newrelic-instrumentation-java",
-					Command:      []string{"cp", "/newrelic-agent.jar", "/newrelic-instrumentation/newrelic-agent.jar"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
-				}},
-				Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
-			}},
 			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "java"}, LicenseKeySecret: "newrelic-key-secret"}},
 		},
 	}

--- a/src/apm/nodejs_test.go
+++ b/src/apm/nodejs_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestNodejsInjector_Language(t *testing.T) {
@@ -64,25 +66,30 @@ func TestNodejsInjector_Inject(t *testing.T) {
 			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 				{Name: "test"},
 			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "test",
-					Env: []corev1.EnvVar{
-						{Name: "NODE_OPTIONS", Value: " --require /newrelic-instrumentation/newrelicinstrumentation.js"},
-						{Name: "NEW_RELIC_APP_NAME", Value: "test"},
-						{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
-						{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
-						{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
-					},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "NODE_OPTIONS", Value: " --require /newrelic-instrumentation/newrelicinstrumentation.js"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:         "newrelic-instrumentation-nodejs",
+						Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				}},
-				InitContainers: []corev1.Container{{
-					Name:         "newrelic-instrumentation-nodejs",
-					Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
-				}},
-				Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
-			}},
 			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "nodejs"}, LicenseKeySecret: "newrelic-key-secret"}},
 		},
 	}

--- a/src/apm/php_test.go
+++ b/src/apm/php_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestPhpInjector_Language(t *testing.T) {
@@ -74,7 +75,11 @@ func TestPhpInjector_Inject(t *testing.T) {
 				}},
 			},
 			expectedPod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"instrumentation.newrelic.com/php-version": "8.3"}},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"instrumentation.newrelic.com/php-version": "8.3"},
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name: "test",

--- a/src/apm/python_test.go
+++ b/src/apm/python_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestPythonInjector_Language(t *testing.T) {
@@ -64,25 +66,29 @@ func TestPythonInjector_Inject(t *testing.T) {
 			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 				{Name: "test"},
 			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "test",
-					Env: []corev1.EnvVar{
-						{Name: "PYTHONPATH", Value: "/newrelic-instrumentation"},
-						{Name: "NEW_RELIC_APP_NAME", Value: "test"},
-						{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
-						{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
-						{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
-					},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				}, Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "PYTHONPATH", Value: "/newrelic-instrumentation"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:         "newrelic-instrumentation-python",
+						Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				}},
-				InitContainers: []corev1.Container{{
-					Name:         "newrelic-instrumentation-python",
-					Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
-				}},
-				Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
-			}},
 			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "python"}, LicenseKeySecret: "newrelic-key-secret"}},
 		},
 	}

--- a/src/apm/ruby_test.go
+++ b/src/apm/ruby_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/newrelic/k8s-agents-operator/src/api/v1alpha2"
+	"github.com/newrelic/k8s-agents-operator/src/internal/version"
 )
 
 func TestRubyInjector_Language(t *testing.T) {
@@ -64,25 +66,29 @@ func TestRubyInjector_Inject(t *testing.T) {
 			pod: corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
 				{Name: "test"},
 			}}},
-			expectedPod: corev1.Pod{Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "test",
-					Env: []corev1.EnvVar{
-						{Name: "RUBYOPT", Value: "-r /newrelic-instrumentation/lib/boot/strap"},
-						{Name: "NEW_RELIC_APP_NAME", Value: "test"},
-						{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
-						{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
-						{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
-					},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				}, Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "RUBYOPT", Value: "-r /newrelic-instrumentation/lib/boot/strap"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:         "newrelic-instrumentation-ruby",
+						Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				}},
-				InitContainers: []corev1.Container{{
-					Name:         "newrelic-instrumentation-ruby",
-					Command:      []string{"cp", "-a", "/instrumentation/.", "/newrelic-instrumentation/"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
-				}},
-				Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
-			}},
 			inst: v1alpha2.Instrumentation{Spec: v1alpha2.InstrumentationSpec{Agent: v1alpha2.Agent{Language: "ruby"}, LicenseKeySecret: "newrelic-key-secret"}},
 		},
 	}

--- a/src/internal/webhookhandler/webhookhandler_suite_test.go
+++ b/src/internal/webhookhandler/webhookhandler_suite_test.go
@@ -20,10 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"io"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -31,6 +28,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -292,7 +293,10 @@ func TestPodMutationHandler_Handle(t *testing.T) {
 				},
 			},
 			expectedPod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "alpine1", Namespace: "default", Labels: map[string]string{"inject": "python"}},
+				ObjectMeta: metav1.ObjectMeta{Name: "alpine1", Namespace: "default", Labels: map[string]string{
+					"inject":                                 "python",
+					apm.DescK8sAgentOperatorVersionLabelName: ""},
+				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{
@@ -380,7 +384,10 @@ func TestPodMutationHandler_Handle(t *testing.T) {
 				},
 			},
 			expectedPod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "alpine2", Namespace: "default", Labels: map[string]string{"inject": "php"}},
+				ObjectMeta: metav1.ObjectMeta{Name: "alpine2", Namespace: "default", Labels: map[string]string{
+					"inject":                                 "php",
+					apm.DescK8sAgentOperatorVersionLabelName: ""},
+				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{


### PR DESCRIPTION
## Description
https://new-relic.atlassian.net/browse/NR-311790

1.
```image: newrelic/newrelic-java-init:latest
        env:
         - name: NEW_RELIC_LABELS
           value: "team:k8s"
  ```
  Given this user provided label, the final value of NEW_RELIC_LABELS will be "team:k8s,operator:auto-injection"
  
2. Add pod label "k8s_agents_operator_version:{appVersionNo}" to every mutated pod.


  


## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  