### PR TITLE
chore: Make sure ini scan dir is extended

### DIFF
--- a/src/apm/php.go
+++ b/src/apm/php.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	envIniScanDirKey     = "PHP_INI_SCAN_DIR"
-	envIniScanDirVal     = "/newrelic-instrumentation/php-agent/ini"
+	envIniScanDirVal     = ":/newrelic-instrumentation/php-agent/ini"
 	phpInitContainerName = initContainerName + "-php"
 )
 

--- a/src/apm/php_test.go
+++ b/src/apm/php_test.go
@@ -85,7 +85,7 @@ func TestPhpInjector_Inject(t *testing.T) {
 						Name: "test",
 						Env: []corev1.EnvVar{
 							{Name: "a", Value: "a"},
-							{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+							{Name: "PHP_INI_SCAN_DIR", Value: ":/newrelic-instrumentation/php-agent/ini"},
 							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
 							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
@@ -96,7 +96,7 @@ func TestPhpInjector_Inject(t *testing.T) {
 						Name: "newrelic-instrumentation-php",
 						Env: []corev1.EnvVar{
 							{Name: "a", Value: "a"},
-							{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+							{Name: "PHP_INI_SCAN_DIR", Value: ":/newrelic-instrumentation/php-agent/ini"},
 							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
 							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},

--- a/src/internal/webhookhandler/webhookhandler_suite_test.go
+++ b/src/internal/webhookhandler/webhookhandler_suite_test.go
@@ -398,7 +398,7 @@ func TestPodMutationHandler_Handle(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{Name: "a", Value: "a"},
 								{Name: "b", Value: "b"},
-								{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+								{Name: "PHP_INI_SCAN_DIR", Value: ":/newrelic-instrumentation/php-agent/ini"},
 								{Name: "NEW_RELIC_APP_NAME", Value: "alpine2"},
 								{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 								{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
@@ -424,7 +424,7 @@ func TestPodMutationHandler_Handle(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{Name: "a", Value: "a"},
 								{Name: "b", Value: "b"},
-								{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+								{Name: "PHP_INI_SCAN_DIR", Value: ":/newrelic-instrumentation/php-agent/ini"},
 								{Name: "NEW_RELIC_APP_NAME", Value: "alpine2"},
 								{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 								{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},


### PR DESCRIPTION
## Description

This will ensure that if the flag `--with-config-file-scan-dir` is set, it won't override it but extend it. 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  