### PR TITLE
fix(php): add php 8.4 to `acceptableLangs`

### DIFF
--- a/api/v1alpha2/instrumentation_webhook.go
+++ b/api/v1alpha2/instrumentation_webhook.go
@@ -117,7 +117,7 @@ func (r *InstrumentationValidator) validate(inst *Instrumentation) (admission.Wa
 		"go",
 		"java",
 		"nodejs",
-		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3", "php-8.4",
+		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3",
 		"python",
 		"ruby",
 	}

--- a/api/v1alpha2/instrumentation_webhook.go
+++ b/api/v1alpha2/instrumentation_webhook.go
@@ -117,7 +117,7 @@ func (r *InstrumentationValidator) validate(inst *Instrumentation) (admission.Wa
 		"go",
 		"java",
 		"nodejs",
-		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3",
+		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3", "php-8.4",
 		"python",
 		"ruby",
 	}

--- a/api/v1beta1/instrumentation_webhook.go
+++ b/api/v1beta1/instrumentation_webhook.go
@@ -117,7 +117,7 @@ func (r *InstrumentationValidator) validate(inst *Instrumentation) (admission.Wa
 		"go",
 		"java",
 		"nodejs",
-		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3",
+		"php-7.2", "php-7.3", "php-7.4", "php-8.0", "php-8.1", "php-8.2", "php-8.3", "php-8.4",
 		"python",
 		"ruby",
 	}


### PR DESCRIPTION
## Description
Adds PHP 8.4 to the `acceptableLangs` list for v1alpha2 and v1beta1. Allows release of init containers with PHP 8.4 support.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [x] This change requires changes in testing:
  - [x] unit tests
  - [x] E2E tests
  