### PR TITLE
fix: php injector

### DIFF
--- a/internal/apm/helper.go
+++ b/internal/apm/helper.go
@@ -191,7 +191,9 @@ func setEnvVar(container *corev1.Container, envVarName string, envVarValue strin
 		return
 	}
 	if concatValues {
-		container.Env[idx].Value = fmt.Sprintf("%s:%s", container.Env[idx].Value, envVarValue)
+		if !strings.Contains(":"+container.Env[idx].Value+":", ":"+envVarValue+":") {
+			container.Env[idx].Value = fmt.Sprintf("%s:%s", container.Env[idx].Value, envVarValue)
+		}
 	}
 }
 

--- a/internal/apm/php_test.go
+++ b/internal/apm/php_test.go
@@ -98,8 +98,58 @@ func TestPhpInjector_Inject(t *testing.T) {
 					InitContainers: []corev1.Container{{
 						Name: "newrelic-instrumentation-php",
 						Env: []corev1.EnvVar{
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+							{Name: "NEW_RELIC_LICENSE_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "newrelic-key-secret"}, Key: "new_relic_license_key", Optional: &vtrue}}},
+						},
+						Command:      []string{"/bin/sh"},
+						Args:         []string{"-c", "cp -a /instrumentation/. /newrelic-instrumentation/ && /newrelic-instrumentation/k8s-php-install.sh 20230831 && /newrelic-instrumentation/nr_env_to_ini.sh"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "newrelic-instrumentation", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+				},
+			},
+			inst: current.Instrumentation{Spec: current.InstrumentationSpec{Agent: current.Agent{Language: "php-8.3"}, LicenseKeySecret: "newrelic-key-secret"}},
+		},
+		{
+			name: "a container, instrumentation, with existing env PHP_INI_SCAN_DIR",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"instrumentation.newrelic.com/php-version": "8.3"}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{
+						Name: "test",
+						Env: []corev1.EnvVar{
 							{Name: "a", Value: "a"},
-							{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+							{Name: "PHP_INI_SCAN_DIR", Value: "fakepath"},
+						},
+					},
+				}},
+			},
+			expectedPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"instrumentation.newrelic.com/php-version": "8.3",
+						"newrelic.com/instrumentation-versions":    `{"/":"/0"}`,
+					},
+					Labels: map[string]string{
+						DescK8sAgentOperatorVersionLabelName: version.Get().Operator},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "test",
+						Env: []corev1.EnvVar{
+							{Name: "a", Value: "a"},
+							{Name: "PHP_INI_SCAN_DIR", Value: "fakepath:/newrelic-instrumentation/php-agent/ini"},
+							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
+							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
+							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "newrelic-instrumentation", MountPath: "/newrelic-instrumentation"}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "newrelic-instrumentation-php",
+						Env: []corev1.EnvVar{
 							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
 							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},

--- a/internal/apm/php_test.go
+++ b/internal/apm/php_test.go
@@ -119,7 +119,15 @@ func TestPhpInjector_Inject(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			i := &PhpInjector{acceptVersion: acceptVersion("php-8.3")}
-			actualPod, err := i.Inject(ctx, test.inst, test.ns, test.pod)
+			// inject multiple times to assert that it's idempotent
+			var err error
+			var actualPod corev1.Pod
+			for ic := 0; ic < 3; ic++ {
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				if err != nil {
+					break
+				}
+			}
 			errStr := ""
 			if err != nil {
 				errStr = err.Error()

--- a/internal/webhook/podmutationhandler_suite_test.go
+++ b/internal/webhook/podmutationhandler_suite_test.go
@@ -400,9 +400,6 @@ func TestPodMutationHandler_Handle(t *testing.T) {
 							Command: []string{"/bin/sh"},
 							Args:    []string{"-c", "cp -a /instrumentation/. /newrelic-instrumentation/ && /newrelic-instrumentation/k8s-php-install.sh 20230831 && /newrelic-instrumentation/nr_env_to_ini.sh"},
 							Env: []corev1.EnvVar{
-								{Name: "a", Value: "a"},
-								{Name: "b", Value: "b"},
-								{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
 								{Name: "NEW_RELIC_APP_NAME", Value: "alpine2"},
 								{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 								{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Fixes possible issue where injecting the php agent could fail to mutate the pod with multiple mutating webhooks
PHP uses a more generic function, though it's the only consumer of that function.. currently
Changes how env gets copied into the sidecar, restricting the env vars to newrelic env vars

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  