### PR TITLE
fix: dotnet injector

### DIFF
--- a/internal/apm/dotnet.go
+++ b/internal/apm/dotnet.go
@@ -17,8 +17,6 @@ package apm
 
 import (
 	"context"
-	"errors"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/newrelic/k8s-agents-operator/api/current"
@@ -71,18 +69,6 @@ func (i DotnetInjector) Inject(ctx context.Context, inst current.Instrumentation
 	firstContainer := 0
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
-
-	// check if CORECLR_NEWRELIC_HOME env var is already set in the container
-	// if it is already set, then we assume that .NET newrelic-instrumentation is already configured for this container
-	if getIndexOfEnv(container.Env, envDotnetNewrelicHome) > -1 {
-		return pod, errors.New("CORECLR_NEWRELIC_HOME environment variable is already set in the container")
-	}
-
-	// check if CORECLR_NEWRELIC_HOME env var is already set in the .NET instrumentation spec
-	// if it is already set, then we assume that .NET newrelic-instrumentation is already configured for this container
-	if getIndexOfEnv(inst.Spec.Agent.Env, envDotnetNewrelicHome) > -1 {
-		return pod, errors.New("CORECLR_NEWRELIC_HOME environment variable is already set in the .NET instrumentation spec")
-	}
 
 	// inject .NET instrumentation spec env vars.
 	for _, env := range inst.Spec.Agent.Env {

--- a/internal/apm/dotnet_test.go
+++ b/internal/apm/dotnet_test.go
@@ -104,7 +104,15 @@ func TestDotnetInjector_Inject(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			i := &DotnetInjector{}
-			actualPod, err := i.Inject(ctx, test.inst, test.ns, test.pod)
+			// inject multiple times to assert that it's idempotent
+			var err error
+			var actualPod corev1.Pod
+			for ic := 0; ic < 3; ic++ {
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				if err != nil {
+					break
+				}
+			}
 			errStr := ""
 			if err != nil {
 				errStr = err.Error()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Fixes possible issue where injecting the dotnet agent could fail to mutate the pod with multiple mutating webhooks, the reason for this one is because it just outright fails.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  