### PR TITLE
Make healthprobe, metrics service, webhook service ports and hostnetwork mode configurable

### DIFF
--- a/charts/k8s-agents-operator/README.md
+++ b/charts/k8s-agents-operator/README.md
@@ -293,6 +293,7 @@ If you want to see a list of all available charts and releases, check [index.yam
 | affinity | object | `{}` | Sets all pods' affinities. Can be configured also with `global.affinity` |
 | containerSecurityContext | object | `{}` | Sets all security context (at container level). Can be configured also with `global.securityContext.container` |
 | controllerManager.manager.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Sets security context (at container level) for the manager. Overrides `containerSecurityContext` and `global.containerSecurityContext` |
+| hostNetwork | bool | `false` | Sets hostNetwork mode|
 | controllerManager.manager.image.pullPolicy | string | `nil` |  |
 | controllerManager.manager.image.repository | string | `"newrelic/k8s-agents-operator"` | Sets the repository and image to use for the manager. Please ensure you're using trusted New Relic images. |
 | controllerManager.manager.image.version | string | `nil` | Sets the manager image version to retrieve. Could be a tag i.e. "v0.17.0" or a SHA digest i.e. "sha256:e2399e70e99ac370ca6a3c7e5affa9655da3b246d0ada77c40ed155b3726ee2e" |
@@ -306,6 +307,7 @@ If you want to see a list of all available charts and releases, check [index.yam
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
 | labels | object | `{}` | Additional labels for chart objects |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
+| heathProbe.port | int | `8081` | HealthProbe binding address |
 | metricsService.ports[0].name | string | `"https"` |  |
 | metricsService.ports[0].port | int | `8443` |  |
 | metricsService.ports[0].protocol | string | `"TCP"` |  |

--- a/charts/k8s-agents-operator/templates/deployment.yaml
+++ b/charts/k8s-agents-operator/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       {{- with include "newrelic.common.securityContext.pod" . }}
       securityContext:
@@ -42,11 +45,12 @@ spec:
           {{- . | nindent 10 }}
         {{- end }}
         args:
-        - --metrics-bind-address=:8443
+        - --metrics-bind-address=:{{ (index .Values.metricsService.ports 0).targetPort }}
         {{- if .Values.controllerManager.manager.leaderElection.enabled }}
         - --leader-elect
         {{- end }}
-        - --health-probe-bind-address=:8081
+        - --health-probe-bind-address=:{{ .Values.heathProbe.port }}
+        - --webhook-service-bind-address=:{{ (index .Values.webhookService.ports 0).targetPort }}
         command:
         - /bin/operator
         env:
@@ -63,17 +67,17 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.heathProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         ports:
-        - containerPort: 9443
+        - containerPort: {{ (index .Values.webhookService.ports 0).targetPort }}
           name: webhook-server
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.heathProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/charts/k8s-agents-operator/values.yaml
+++ b/charts/k8s-agents-operator/values.yaml
@@ -35,6 +35,10 @@ podSecurityContext:
 # -- Sets all security context (at container level). Can be configured also with `global.securityContext.container`
 containerSecurityContext: {}
 
+# If hostNetwork is set to true, the webhook server will bind to the host network.
+# @default -- `false`
+hostNetwork: false
+
 kubernetesClusterDomain: cluster.local
 
 controllerManager:
@@ -75,6 +79,12 @@ serviceAccount:
   name: ""
   # Specify any annotations to add to the ServiceAccount
   annotations:
+
+# -- healthprobe settings
+# -- healthprobe is a simple HTTP server that listens on the specified port and responds with 200 OK
+# -- when the operator is healthy. It is used by Kubernetes to check the health of the operator.
+heathProbe:
+  port: 8081
 
 metricsService:
   ports:


### PR DESCRIPTION
Make binding address for metrics service configurable via values.yaml
Make health probe bind address configurable via values.yaml
Make hostnetwork mode configurable via values.yaml
Make binding address for webhook service configurable via a new flag --webhook-service-bind-address and values.yaml 