### PR TITLE
Php/fix scan dir

### DIFF
--- a/internal/apm/helper.go
+++ b/internal/apm/helper.go
@@ -184,10 +184,17 @@ func getValueFromEnv(envVars []corev1.EnvVar, name string) (string, bool) {
 func setEnvVar(container *corev1.Container, envVarName string, envVarValue string, concatValues bool) {
 	idx := getIndexOfEnv(container.Env, envVarName)
 	if idx < 0 {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  envVarName,
-			Value: envVarValue,
-		})
+		if concatValues {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  envVarName,
+				Value: ":"+envVarValue,
+			})
+		} else {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  envVarName,
+				Value: envVarValue,
+			})
+		}
 		return
 	}
 	if concatValues {

--- a/internal/apm/php_test.go
+++ b/internal/apm/php_test.go
@@ -88,7 +88,7 @@ func TestPhpInjector_Inject(t *testing.T) {
 						Name: "test",
 						Env: []corev1.EnvVar{
 							{Name: "a", Value: "a"},
-							{Name: "PHP_INI_SCAN_DIR", Value: "/newrelic-instrumentation/php-agent/ini"},
+							{Name: "PHP_INI_SCAN_DIR", Value: ":/newrelic-instrumentation/php-agent/ini"},
 							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
 							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
In the case of `PHP_INI_SCAN_DIR` not being explicitly set or in the case of there is no scan dir set because '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' was used. because This code is not preserving the default because it falls into the following case and returns with no `:` being set (`:` is required to get the default: https://www.php.net/manual/en/configuration.file.php#configuration.file.scan). https://github.com/newrelic/k8s-agents-operator/blob/main/internal/apm/helper.go#L186 Which means only `/newrelic-instrumentation/php-agent/ini` (see here: https://github.com/newrelic/k8s-agents-operator/blob/164556c58c0cedb7ff8eec9796dc2738c328fbb3/internal/apm/php.go#L30) is getting set as the `PHP_INI_SCAN_DIR` and all INIs in the `--with-config-file-scan-dir` are being lost.

Test updated to show `:` being preserved when no scan dir is detected.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ x] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [x] This change requires changes in testing:
  - [x] unit tests
  - [ ] E2E tests
  