### PR TITLE
feat: Minor improvements

### DIFF
--- a/internal/apm/dotnet.go
+++ b/internal/apm/dotnet.go
@@ -70,18 +70,14 @@ func (i DotnetInjector) Inject(ctx context.Context, inst current.Instrumentation
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
 
-	// inject .NET instrumentation spec env vars.
-	for _, env := range inst.Spec.Agent.Env {
-		idx := getIndexOfEnv(container.Env, env.Name)
-		if idx == -1 {
-			container.Env = append(container.Env, env)
-		}
+	if err := validateContainerEnv(container.Env, envDotnetCoreClrEnableProfiling, envDotnetCoreClrProfiler, envDotnetCoreClrProfilerPath, envDotnetNewrelicHome); err != nil {
+		return pod, err
 	}
-
-	setEnvVar(container, envDotnetCoreClrEnableProfiling, dotnetCoreClrEnableProfilingEnabled, false)
-	setEnvVar(container, envDotnetCoreClrProfiler, dotnetCoreClrProfilerID, false)
-	setEnvVar(container, envDotnetCoreClrProfilerPath, dotnetCoreClrProfilerPath, false)
-	setEnvVar(container, envDotnetNewrelicHome, dotnetNewrelicHomePath, false)
+	setEnvVar(container, envDotnetCoreClrEnableProfiling, dotnetCoreClrEnableProfilingEnabled, false, "")
+	setEnvVar(container, envDotnetCoreClrProfiler, dotnetCoreClrProfilerID, false, "")
+	setEnvVar(container, envDotnetCoreClrProfilerPath, dotnetCoreClrProfilerPath, false, "")
+	setEnvVar(container, envDotnetNewrelicHome, dotnetNewrelicHomePath, false, "")
+	setContainerEnvFromInst(container, inst)
 
 	if isContainerVolumeMissing(container, volumeName) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{

--- a/internal/apm/dotnet_test.go
+++ b/internal/apm/dotnet_test.go
@@ -107,11 +107,13 @@ func TestDotnetInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {

--- a/internal/apm/java.go
+++ b/internal/apm/java.go
@@ -17,8 +17,6 @@ package apm
 
 import (
 	"context"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/newrelic/k8s-agents-operator/api/current"
@@ -68,29 +66,11 @@ func (i *JavaInjector) Inject(ctx context.Context, inst current.Instrumentation,
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
 
-	err := validateContainerEnv(container.Env, envJavaToolsOptions)
-	if err != nil {
+	if err := validateContainerEnv(container.Env, envJavaToolsOptions); err != nil {
 		return pod, err
 	}
-
-	// inject Java instrumentation spec env vars.
-	for _, env := range inst.Spec.Agent.Env {
-		idx := getIndexOfEnv(container.Env, env.Name)
-		if idx == -1 {
-			container.Env = append(container.Env, env)
-		}
-	}
-
-	if idx := getIndexOfEnv(container.Env, envJavaToolsOptions); idx == -1 {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  envJavaToolsOptions,
-			Value: javaJVMArgument,
-		})
-	} else {
-		if !strings.Contains(" "+container.Env[idx].Value+" ", " "+javaJVMArgument+" ") {
-			container.Env[idx].Value = container.Env[idx].Value + " " + javaJVMArgument
-		}
-	}
+	setEnvVar(container, envJavaToolsOptions, javaJVMArgument, true, " ")
+	setContainerEnvFromInst(container, inst)
 
 	if inst.Spec.AgentConfigMap != "" {
 		injectAgentConfigMap(&pod, firstContainer, inst.Spec.AgentConfigMap)
@@ -136,6 +116,7 @@ func (i *JavaInjector) Inject(ctx context.Context, inst current.Instrumentation,
 
 	pod = addAnnotationToPodFromInstrumentationVersion(ctx, pod, inst)
 
+	var err error
 	if pod, err = i.injectHealth(ctx, inst, ns, pod, firstContainer, -1); err != nil {
 		return pod, err
 	}

--- a/internal/apm/java_test.go
+++ b/internal/apm/java_test.go
@@ -226,11 +226,13 @@ func TestJavaInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {

--- a/internal/apm/nodejs_test.go
+++ b/internal/apm/nodejs_test.go
@@ -144,11 +144,13 @@ func TestNodejsInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {

--- a/internal/apm/php.go
+++ b/internal/apm/php.go
@@ -103,14 +103,11 @@ func (i *PhpInjector) Inject(ctx context.Context, inst current.Instrumentation, 
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
 
-	setEnvVar(container, envIniScanDirKey, envIniScanDirVal, true)
-
-	// inject PHP instrumentation spec env vars.
-	for _, env := range inst.Spec.Agent.Env {
-		if idx := getIndexOfEnv(container.Env, env.Name); idx == -1 {
-			container.Env = append(container.Env, env)
-		}
+	if err := validateContainerEnv(container.Env, envIniScanDirKey); err != nil {
+		return pod, err
 	}
+	setEnvVar(container, envIniScanDirKey, envIniScanDirVal, true, ":")
+	setContainerEnvFromInst(container, inst)
 
 	if isContainerVolumeMissing(container, volumeName) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{

--- a/internal/apm/php_test.go
+++ b/internal/apm/php_test.go
@@ -172,11 +172,13 @@ func TestPhpInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {

--- a/internal/apm/python.go
+++ b/internal/apm/python.go
@@ -17,12 +17,8 @@ package apm
 
 import (
 	"context"
-	"fmt"
-	"strings"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/newrelic/k8s-agents-operator/api/current"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -67,30 +63,11 @@ func (i *PythonInjector) Inject(ctx context.Context, inst current.Instrumentatio
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
 
-	err := validateContainerEnv(container.Env, envPythonPath)
-	if err != nil {
+	if err := validateContainerEnv(container.Env, envPythonPath); err != nil {
 		return pod, err
 	}
-
-	// inject Python instrumentation spec env vars.
-	for _, env := range inst.Spec.Agent.Env {
-		idx := getIndexOfEnv(container.Env, env.Name)
-		if idx == -1 {
-			container.Env = append(container.Env, env)
-		}
-	}
-
-	idx := getIndexOfEnv(container.Env, envPythonPath)
-	if idx == -1 {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  envPythonPath,
-			Value: pythonPathPrefix,
-		})
-	} else if idx > -1 {
-		if !strings.Contains(":"+container.Env[idx].Value+":", ":"+pythonPathPrefix+":") {
-			container.Env[idx].Value = fmt.Sprintf("%s:%s", pythonPathPrefix, container.Env[idx].Value)
-		}
-	}
+	setEnvVar(container, envPythonPath, pythonPathPrefix, true, ":")
+	setContainerEnvFromInst(container, inst)
 
 	if isContainerVolumeMissing(container, volumeName) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
@@ -124,6 +101,7 @@ func (i *PythonInjector) Inject(ctx context.Context, inst current.Instrumentatio
 
 	pod = addAnnotationToPodFromInstrumentationVersion(ctx, pod, inst)
 
+	var err error
 	if pod, err = i.injectHealth(ctx, inst, ns, pod, firstContainer, -1); err != nil {
 		return pod, err
 	}

--- a/internal/apm/python_test.go
+++ b/internal/apm/python_test.go
@@ -117,7 +117,7 @@ func TestPythonInjector_Inject(t *testing.T) {
 					Containers: []corev1.Container{{
 						Name: "test",
 						Env: []corev1.EnvVar{
-							{Name: "PYTHONPATH", Value: "/newrelic-instrumentation:fakepath"},
+							{Name: "PYTHONPATH", Value: "fakepath:/newrelic-instrumentation"},
 							{Name: "NEW_RELIC_APP_NAME", Value: "test"},
 							{Name: "NEW_RELIC_LABELS", Value: "operator:auto-injection"},
 							{Name: "NEW_RELIC_K8S_OPERATOR_ENABLED", Value: "true"},
@@ -142,11 +142,13 @@ func TestPythonInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {

--- a/internal/apm/ruby.go
+++ b/internal/apm/ruby.go
@@ -17,8 +17,6 @@ package apm
 
 import (
 	"context"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/newrelic/k8s-agents-operator/api/current"
@@ -66,30 +64,11 @@ func (i *RubyInjector) Inject(ctx context.Context, inst current.Instrumentation,
 	// caller checks if there is at least one container.
 	container := &pod.Spec.Containers[firstContainer]
 
-	err := validateContainerEnv(container.Env, envRubyOpt)
-	if err != nil {
+	if err := validateContainerEnv(container.Env, envRubyOpt); err != nil {
 		return pod, err
 	}
-
-	// inject Ruby instrumentation spec env vars.
-	for _, env := range inst.Spec.Agent.Env {
-		idx := getIndexOfEnv(container.Env, env.Name)
-		if idx == -1 {
-			container.Env = append(container.Env, env)
-		}
-	}
-
-	idx := getIndexOfEnv(container.Env, envRubyOpt)
-	if idx == -1 {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  envRubyOpt,
-			Value: rubyOptRequire,
-		})
-	} else if idx > -1 {
-		if !strings.Contains(" "+container.Env[idx].Value+" ", " "+rubyOptRequire+" ") {
-			container.Env[idx].Value = container.Env[idx].Value + " " + rubyOptRequire
-		}
-	}
+	setEnvVar(container, envRubyOpt, rubyOptRequire, true, " ")
+	setContainerEnvFromInst(container, inst)
 
 	if isContainerVolumeMissing(container, volumeName) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
@@ -123,6 +102,7 @@ func (i *RubyInjector) Inject(ctx context.Context, inst current.Instrumentation,
 
 	pod = addAnnotationToPodFromInstrumentationVersion(ctx, pod, inst)
 
+	var err error
 	if pod, err = i.injectHealth(ctx, inst, ns, pod, firstContainer, -1); err != nil {
 		return pod, err
 	}

--- a/internal/apm/ruby_test.go
+++ b/internal/apm/ruby_test.go
@@ -145,11 +145,13 @@ func TestRubyInjector_Inject(t *testing.T) {
 			// inject multiple times to assert that it's idempotent
 			var err error
 			var actualPod corev1.Pod
+			testPod := test.pod
 			for ic := 0; ic < 3; ic++ {
-				actualPod, err = i.Inject(ctx, test.inst, test.ns, test.pod)
+				actualPod, err = i.Inject(ctx, test.inst, test.ns, testPod)
 				if err != nil {
 					break
 				}
+				testPod = actualPod
 			}
 			errStr := ""
 			if err != nil {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

- Add some checks for DotNet
  - Prevent mutating a pod which has already been configured for a profiler with different values
  - Ensures that the configuration exists in the pod, rather than a configmap or something else (ValueFrom)
- Change the other in which paths get appended to the PYTHONPATH
- Minor changes to testing to ensure we try to mutate a pod from an already mutated pod
- Simplify some code

## Type of change
<!-- Please check the relevant option. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [x] unit tests
  - [ ] E2E tests
  