### PR TITLE
feat: provide way to disable CRD installation with Helm chart

### DIFF
--- a/charts/k8s-agents-operator/README.md
+++ b/charts/k8s-agents-operator/README.md
@@ -302,7 +302,7 @@ If you want to see a list of all available charts and releases, check [index.yam
 | controllerManager.manager.resources.requests.cpu | string | `"100m"` |  |
 | controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
 | controllerManager.replicas | int | `1` |  |
-| crds.enabled | bool | `true` | Controls if CRDs should be installed as part of the Helm installation. |
+| crds.enabled | bool | `true` |  |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
 | healthProbe | object | `{"port":8081}` | when the operator is healthy. It is used by Kubernetes to check the health of the operator. |
 | hostNetwork | bool | `false` |  |

--- a/charts/k8s-agents-operator/README.md
+++ b/charts/k8s-agents-operator/README.md
@@ -302,6 +302,7 @@ If you want to see a list of all available charts and releases, check [index.yam
 | controllerManager.manager.resources.requests.cpu | string | `"100m"` |  |
 | controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
 | controllerManager.replicas | int | `1` |  |
+| crds.enabled | bool | `true` | Controls if CRDs should be installed as part of the Helm installation. |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
 | healthProbe | object | `{"port":8081}` | when the operator is healthy. It is used by Kubernetes to check the health of the operator. |
 | hostNetwork | bool | `false` |  |

--- a/charts/k8s-agents-operator/templates/instrumentation-crd.yaml
+++ b/charts/k8s-agents-operator/templates/instrumentation-crd.yaml
@@ -200,6 +200,7 @@ webhooks:
         resources:
           - instrumentations
     sideEffects: None
+{{- if .Values.crds.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1216,3 +1217,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/charts/k8s-agents-operator/values.yaml
+++ b/charts/k8s-agents-operator/values.yaml
@@ -41,6 +41,9 @@ hostNetwork: false
 
 kubernetesClusterDomain: cluster.local
 
+crds:
+  enabled: true
+
 controllerManager:
   replicas: 1
 


### PR DESCRIPTION
## Description

Adding a configuraiton option to allow disabling of CRD installation as part of the chart.

In a GitOps workflow, having the chart install CRDs leads to a chicken-and-egg problem: the Instrumentation objects in our repo can't be synced because the CRD doesn't exist yet, and the CRD can't be installed via the chart because syncing is blocked by the missing CRD.

For this reason we manage all of our CRDs out-of-chart to ensure that this ordering issue does not casue any issues and that we have explicit control over the CRD lifecycle.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [X] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  