### PR TITLE
feat: generate container names longer than 63 chars

### DIFF
--- a/internal/apm/dotnet.go
+++ b/internal/apm/dotnet.go
@@ -53,7 +53,7 @@ func (i *DotnetInjector) InjectContainer(ctx context.Context, inst current.Instr
 		return corev1.Pod{}, fmt.Errorf("container %q not found", containerName)
 	}
 
-	initContainerName := "nri-dotnet--" + containerName
+	initContainerName := generateContainerName("nri-dotnet--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + volumeName
 	coreClrProfilerPath := mountPath + "/libNewRelicProfiler.so"

--- a/internal/apm/helper.go
+++ b/internal/apm/helper.go
@@ -16,6 +16,7 @@ limitations under the License.
 package apm
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -286,4 +287,14 @@ func insertContainerBeforeIndex(containers []corev1.Container, index int, newCon
 	initContainers[index] = newContainer
 	copy(initContainers[index+1:], containers[index:])
 	return initContainers
+}
+
+func generateContainerName(namePrefix string) string {
+	maxContainerNameLength := 63
+	hashLength := 7
+	if len(namePrefix) > maxContainerNameLength {
+
+		return strings.TrimRight(namePrefix[:maxContainerNameLength-hashLength-1], "-") + "-" + fmt.Sprintf("%x", sha256.Sum256([]byte(namePrefix)))[:hashLength]
+	}
+	return namePrefix
 }

--- a/internal/apm/java.go
+++ b/internal/apm/java.go
@@ -46,7 +46,7 @@ func (i *JavaInjector) InjectContainer(ctx context.Context, inst current.Instrum
 		return corev1.Pod{}, fmt.Errorf("container %q not found", containerName)
 	}
 
-	initContainerName := "nri-java--" + containerName
+	initContainerName := generateContainerName("nri-java--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + volumeName
 	javaJVMArgument := "-javaagent:" + mountPath + "/newrelic-agent.jar"

--- a/internal/apm/nodejs.go
+++ b/internal/apm/nodejs.go
@@ -45,7 +45,7 @@ func (i *NodejsInjector) InjectContainer(ctx context.Context, inst current.Instr
 		return corev1.Pod{}, fmt.Errorf("container %q not found", containerName)
 	}
 
-	initContainerName := "nri-nodejs--" + containerName
+	initContainerName := generateContainerName("nri-nodejs--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + volumeName
 	nodeRequireArgument := "--require " + mountPath + "/newrelicinstrumentation.js"

--- a/internal/apm/php.go
+++ b/internal/apm/php.go
@@ -80,7 +80,7 @@ func (i *PhpInjector) InjectContainer(ctx context.Context, inst current.Instrume
 		return pod, errors.New("invalid php version")
 	}
 
-	initContainerName := "nri-php--" + containerName
+	initContainerName := generateContainerName("nri-php--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + initContainerName
 	envIniScanDirVal := mountPath + "/php-agent/ini"

--- a/internal/apm/python.go
+++ b/internal/apm/python.go
@@ -45,7 +45,7 @@ func (i *PythonInjector) InjectContainer(ctx context.Context, inst current.Instr
 		return corev1.Pod{}, fmt.Errorf("container %q not found", containerName)
 	}
 
-	initContainerName := "nri-python--" + containerName
+	initContainerName := generateContainerName("nri-python--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + volumeName
 	pythonPathPrefix := mountPath

--- a/internal/apm/ruby.go
+++ b/internal/apm/ruby.go
@@ -44,7 +44,7 @@ func (i *RubyInjector) InjectContainer(ctx context.Context, inst current.Instrum
 		return corev1.Pod{}, fmt.Errorf("container %q not found", containerName)
 	}
 
-	initContainerName := "nri-ruby--" + containerName
+	initContainerName := generateContainerName("nri-ruby--" + containerName)
 	volumeName := initContainerName
 	mountPath := "/" + volumeName
 	rubyOptRequire := "-r " + mountPath + "/lib/boot/strap"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Generates the init container name (which gets a suffix of the targeted container name), only when the container name exceeds the container name length limit of "no more than 63 characters".  What it does is uses our prefix "nri-" + `lang` + "--" `target_container_name` to generate a sha256 hash, truncate to the first 7 characters to get the hash.  The final name will be the full name truncated to 54 characters (trimming off more of there's dashes "-"), and appending the hash to it.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  