### PR TITLE
fix: remove pod mutate on update

### DIFF
--- a/charts/k8s-agents-operator/templates/instrumentation-crd.yaml
+++ b/charts/k8s-agents-operator/templates/instrumentation-crd.yaml
@@ -264,7 +264,6 @@ webhooks:
           - v1
         operations:
           - CREATE
-          - UPDATE
         resources:
           - pods
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -80,7 +80,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/internal/webhook/podmutationhandler.go
+++ b/internal/webhook/podmutationhandler.go
@@ -24,7 +24,7 @@ var (
 	_ PodMutator = (*instrumentation.InstrumentationPodMutator)(nil)
 )
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,sideEffects=none,admissionReviewVersions=v1
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch
 // +kubebuilder:rbac:groups=newrelic.com,resources=instrumentations,verbs=get;list;watch
 // +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=get;list;watch


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

Removes the ability to mutate a pod on an update.

Fixes https://github.com/newrelic/k8s-agents-operator/issues/347

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  