### PR TITLE
feat(appName): add appName via annotation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -36,7 +36,7 @@ helm_resource(
   update_dependencies=False,
   flags=flags_helm,
   image_deps=['tilt.local/operator-dev'],
-  image_keys=[('controllerManager.manager.image.repository', 'controllerManager.manager.image.version')],
+  image_keys=[('controllerManager.manager.image.registry', 'controllerManager.manager.image.repository', 'controllerManager.manager.image.version')],
   resource_deps=[]
 )
 

--- a/internal/apm/base.go
+++ b/internal/apm/base.go
@@ -18,8 +18,8 @@ import (
 	"github.com/newrelic/k8s-agents-operator/api/current"
 )
 
-// NewRelicAppNameAnnotation is the environment variable used to set the New Relic
-// application to all the pods instrumented by the same Instrumentation resource.
+// NewRelicAppNameAnnotation is the annotation used to set the same New Relic application name to all the pods instrumented
+// by the same Instrumentation resource.
 // This does not have precedence over the application name set at the environment variable level, which will be used if defined.
 const NewRelicAppNameAnnotation = "newrelic.com/app-name"
 

--- a/internal/apm/base.go
+++ b/internal/apm/base.go
@@ -18,6 +18,11 @@ import (
 	"github.com/newrelic/k8s-agents-operator/api/current"
 )
 
+// NewRelicAppNameAnnotation is the environment variable used to set the New Relic
+// application to all the pods instrumented by the same Instrumentation resource.
+// This does not have precedence over the application name set at the environment variable level, which will be used if defined.
+const NewRelicAppNameAnnotation = "newrelic.com/app-name"
+
 type baseInjector struct {
 	client client.Client
 	lang   string
@@ -44,21 +49,41 @@ func (i *baseInjector) Language() string {
 	return i.lang
 }
 
-func (i *baseInjector) setContainerEnvAppName(ctx context.Context, ns *corev1.Namespace, pod *corev1.Pod, container *corev1.Container) error {
-	if idx := getIndexOfEnv(container.Env, EnvNewRelicAppName); idx == -1 {
-		name, err := i.getRootResourceName(ctx, ns, pod)
-		if err != nil {
-			return fmt.Errorf("failed to get root resource name for pod > %w", err)
-		}
-		if name == "" {
-			name = container.Name
-		}
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  EnvNewRelicAppName,
-			Value: name,
-		})
+func (i *baseInjector) setContainerEnvAppName(ctx context.Context, ns *corev1.Namespace, pod *corev1.Pod, container *corev1.Container, inst current.Instrumentation) error {
+	// if the EnvNewRelicAppName is already set in the container, we do not override it
+	if idx := getIndexOfEnv(container.Env, EnvNewRelicAppName); idx != -1 {
+		return nil
 	}
+
+	name, err := i.retrieveAppName(ctx, ns, pod, container, inst)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve application name > %w", err)
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  EnvNewRelicAppName,
+		Value: name,
+	})
 	return nil
+}
+
+// retrieveAppName determines the application name to be used for a given pod and container when and environment variable is not already specified.
+// It first checks if the application name is specified in the instrumentation annotations.
+// If not, it attempts to derive the application name from the pod's owner resources (like Deployment, StatefulSet, etc.).
+// If it cannot determine a name from the owners, it defaults to using the pod's name as the application name, falling
+// back to the container name if empty.
+func (i *baseInjector) retrieveAppName(ctx context.Context, ns *corev1.Namespace, pod *corev1.Pod, container *corev1.Container, inst current.Instrumentation) (string, error) {
+	if appName, ok := inst.Annotations[NewRelicAppNameAnnotation]; ok {
+		return appName, nil
+	}
+
+	if rootResourceName, err := i.getRootResourceName(ctx, ns, pod); err != nil {
+		return "", fmt.Errorf("failed to get root resource name for pod > %w", err)
+	} else if rootResourceName != "" {
+		return rootResourceName, nil
+	}
+
+	return container.Name, nil
 }
 
 func (i *baseInjector) getRootResourceName(ctx context.Context, ns *corev1.Namespace, pod *corev1.Pod) (string, error) {

--- a/internal/apm/dotnet.go
+++ b/internal/apm/dotnet.go
@@ -104,7 +104,6 @@ func (i *DotnetInjector) InjectContainer(ctx context.Context, inst current.Instr
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	// This is just an example of setting App Name from Instrumentation spec. The code obviously should be improved.
 	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}

--- a/internal/apm/dotnet.go
+++ b/internal/apm/dotnet.go
@@ -104,7 +104,8 @@ func (i *DotnetInjector) InjectContainer(ctx context.Context, inst current.Instr
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	// This is just an example of setting App Name from Instrumentation spec. The code obviously should be improved.
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/dotnetwindows.go
+++ b/internal/apm/dotnetwindows.go
@@ -146,7 +146,7 @@ func (i *DotnetWindowsInjector) InjectContainer(ctx context.Context, inst curren
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/helper_test.go
+++ b/internal/apm/helper_test.go
@@ -49,7 +49,7 @@ func TestEncodeDecodeAttributes(t *testing.T) {
 	}
 }
 
-func TestGetAppName(t *testing.T) {
+func TestGetRootResourceName(t *testing.T) {
 	tests := []struct {
 		name            string
 		podName         string
@@ -220,6 +220,45 @@ func TestGetAppName(t *testing.T) {
 				t.Errorf("got error %q, want error %q", errStr, test.expectedErrStr)
 			}
 		})
+	}
+}
+
+func TestGetAppName(t *testing.T) {
+
+	// Container name used as app name
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: ""}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "container-name"}}}}
+	checkAppName(t, pod, &pod.Spec.Containers[0], current.Instrumentation{}, "container-name")
+
+	// Pod name used as app name
+	pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-name"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "container-name"}}}}
+	checkAppName(t, pod, &pod.Spec.Containers[0], current.Instrumentation{}, "pod-name")
+
+	// pre-existing env var is not overridden
+	pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-name"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "container-name", Env: []corev1.EnvVar{{Name: EnvNewRelicAppName, Value: "pre-existing-app-name"}}}}}}
+	checkAppName(t, pod, &pod.Spec.Containers[0], current.Instrumentation{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{NewRelicAppNameAnnotation: "app_name_via_annotations"}}}, "pre-existing-app-name")
+
+	// App name from instrumentation annotation
+	pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-name"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "container-name"}}}}
+	checkAppName(t, pod, &pod.Spec.Containers[0], current.Instrumentation{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{NewRelicAppNameAnnotation: "app_name_via_annotations"}}}, "app_name_via_annotations")
+
+	// ErrorPath: Error is expected if root resource name retrieval fails
+	pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-name", OwnerReferences: []metav1.OwnerReference{{Kind: "Job", Name: "not-existing", APIVersion: "appsv1", UID: "1"}}}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "container-name"}}}}
+	err := (&baseInjector{client: k8sClient}).setContainerEnvAppName(context.Background(), &corev1.Namespace{}, pod, &pod.Spec.Containers[0], current.Instrumentation{})
+	if err == nil {
+		t.Fatalf("An error was expected when root resource name retrieval fails, but got nil")
+	}
+}
+
+func checkAppName(t *testing.T, pod *corev1.Pod, container *corev1.Container, inst current.Instrumentation, appName string) {
+	ctx := context.Background()
+	ns := &corev1.Namespace{}
+
+	err := (&baseInjector{client: k8sClient}).setContainerEnvAppName(ctx, ns, pod, container, inst)
+	if err != nil {
+		t.Fatalf("failed to fetch app name, %s", err.Error())
+	}
+	if container.Env[getIndexOfEnv(container.Env, EnvNewRelicAppName)].Value != appName {
+		t.Fatalf("failed to fetch app name, %s", err.Error())
 	}
 }
 

--- a/internal/apm/java.go
+++ b/internal/apm/java.go
@@ -105,7 +105,7 @@ func (i *JavaInjector) InjectContainer(ctx context.Context, inst current.Instrum
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/nodejs.go
+++ b/internal/apm/nodejs.go
@@ -79,7 +79,7 @@ func (i *NodejsInjector) InjectContainer(ctx context.Context, inst current.Instr
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/php.go
+++ b/internal/apm/php.go
@@ -101,7 +101,7 @@ func (i *PhpInjector) InjectContainer(ctx context.Context, inst current.Instrume
 	addPodVolumeIfMissing(&pod, volumeName)
 	addContainerVolumeIfMissing(container, volumeName, mountPath)
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/python.go
+++ b/internal/apm/python.go
@@ -79,7 +79,7 @@ func (i *PythonInjector) InjectContainer(ctx context.Context, inst current.Instr
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)

--- a/internal/apm/ruby.go
+++ b/internal/apm/ruby.go
@@ -78,7 +78,7 @@ func (i *RubyInjector) InjectContainer(ctx context.Context, inst current.Instrum
 		container, _ = util.GetContainerByNameFromPod(&pod, containerName)
 	}
 
-	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container); err != nil {
+	if err := i.setContainerEnvAppName(ctx, &ns, &pod, container, inst); err != nil {
 		return corev1.Pod{}, err
 	}
 	setContainerEnvInjectionDefaults(container)


### PR DESCRIPTION
This PR introduce a new small feature.

Whenever the annotation `newrelic.com/app-name` is found in an instrumentation CR, all the container instrumented thanks to that instrumentation CR will leverage the value of such annotation to populate NEW_RELIC_APP_NAME.

If the annotation is not present or if the user was specifying the APP_NAME via environment variable the behaviour is not changed
  